### PR TITLE
docs: update README with project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,24 @@
-# React + Vite
+# Camilo Mascarell Jorques - CV
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Este proyecto es una aplicación de currículum vitae construida con **React** y **Vite**. Permite presentar información personal y profesional de forma dinámica utilizando componentes de Material UI y datos obtenidos desde una API externa.
 
-Currently, two official plugins are available:
+## Instalación y ejecución
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+```bash
+npm install
+npm run dev
+```
 
-## Expanding the ESLint configuration
+## Funcionalidades principales
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+- Secciones de *About Me*, *Skills*, *Education*, *Experience* y *Practices*.
+- Contenido cargado dinámicamente desde una API REST (`https://cv-api-n6p0.onrender.com`).
+- Diseño responsivo con soporte para cambio de tema claro/oscuro.
+- Generación opcional de CV en PDF mediante `@react-pdf/renderer`.
+
+## Tecnologías
+
+- React + Vite
+- Material UI
+- Axios para consumo de API
+- React Router para navegación


### PR DESCRIPTION
## Summary
- replace generic Vite template README with introduction to the CV project
- document install/run commands
- outline key sections and API usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 'motion' is defined but never used and react-refresh warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68962a8067188332a8571c5e2013bab7