### PR TITLE
chore: add vitest setup and theme toggle tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -32,6 +33,10 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "vitest": "^1.5.0",
+    "jsdom": "^24.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3"
   }
 }

--- a/src/components/__tests__/ThemeToggle.test.jsx
+++ b/src/components/__tests__/ThemeToggle.test.jsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import ThemeToggle from '../ThemeToggle';
+import { ThemeContext } from '../../theme/ThemeContext';
+
+function Wrapper({ children }) {
+  const [mode, setMode] = useState('light');
+  const toggleTheme = () => setMode(prev => prev === 'light' ? 'dark' : 'light');
+  Wrapper.mode = mode;
+  return (
+    <ThemeContext.Provider value={{ mode, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function setup() {
+  render(<ThemeToggle />, { wrapper: Wrapper });
+  return { getMode: () => Wrapper.mode };
+}
+
+test('toggles theme mode and icon', async () => {
+  const user = userEvent.setup();
+  const { getMode } = setup();
+
+  expect(getMode()).toBe('light');
+  expect(screen.getByTestId('DarkModeIcon')).toBeTruthy();
+
+  await user.click(screen.getByRole('button'));
+
+  expect(getMode()).toBe('dark');
+  expect(screen.getByTestId('LightModeIcon')).toBeTruthy();
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.js'
+  }
 })


### PR DESCRIPTION
## Summary
- set up Vitest configuration with jsdom environment
- add ThemeToggle test covering mode toggling and icon changes

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68962c9fc45083329c9b3852fe1817e0