### PR TITLE
Reduce mobile side padding

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -3,13 +3,13 @@ import { Container, Box } from "@mui/material";
 
 export default function Layout({ children }) {
     return (
-        <Container maxWidth="md" sx={{ py: 4 }}>
+        <Container maxWidth="md" disableGutters sx={{ py: 4 }}>
             <Box
                 sx={{
                     display: "flex",
                     flexDirection: "column",
                     gap: 4,
-                    px: { xs: 2, sm: 4 },
+                    px: { xs: 1, sm: 4 },
                 }}
             >
                 {children}


### PR DESCRIPTION
## Summary
- remove Container gutters and shrink horizontal padding on small screens to give content more room on mobile

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68962ee72f3c8332b9725cf96ee2f9b4